### PR TITLE
Set Python image version to 3.6

### DIFF
--- a/python/3/Dockerfile
+++ b/python/3/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 
 ARG GO_VERSION=1.9.4
 ARG DOCKER_VERSION=17.12.0-ce


### PR DESCRIPTION
This PR is to make sure we use a Python 3.6 image for CI until we decide to move our Python projects forward and upgrade to 3.7 explicitly.